### PR TITLE
fix: '''\ and """\ being incorrectly detected

### DIFF
--- a/flake8_broken_line.py
+++ b/flake8_broken_line.py
@@ -13,6 +13,8 @@ pkg_name = 'flake8-broken-line'
 pkg_version: str = pkg_resources.get_distribution(pkg_name).version
 
 _INVALID_LINE_BREAK = re.compile(r'(?<!\\)\\$', re.M)
+_INVALID_MULTILINE_BACKSLASH = re.compile(r'(?<![\']{3}|[\"]{3})\\$', re.M)
+CONDITIONS = [_INVALID_LINE_BREAK, _INVALID_MULTILINE_BACKSLASH]
 _IGNORED_TOKENS = frozenset((
     tokenize.STRING,
     tokenize.COMMENT,
@@ -38,7 +40,7 @@ def check_line_breaks(
         if line_token.start[0] in reported:
             continue  # There might be several tokens on a same line.
 
-        if _INVALID_LINE_BREAK.search(line_token.line):
+        if all(condition.search(line_token.line) for condition in CONDITIONS):
             yield (*line_token.start, _N400, 'check_line_breaks')
             reported.add(line_token.start[0])
 

--- a/tests/fixtures/correct.py
+++ b/tests/fixtures/correct.py
@@ -27,3 +27,13 @@ third_multiline = """
 This is trailing backslash line break with extra spaces: \
 and next line.
 """
+
+fourth_multiline = """\
+This is a multiline block with no prepended newline
+and next line.
+"""
+
+fifth_multiline = '''\
+This is a multiline block with no prepended newline
+and next line.
+'''


### PR DESCRIPTION
The \ after ''' and """ is not a line break. It is used to disable the
leading linebreak in multiline strings

Fixes #138